### PR TITLE
feat: add dependabot to update github action packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This pull request adds a configuration file for Dependabot to automate dependency updates for GitHub Actions workflows. The configuration specifies that updates should be checked monthly.

- Dependabot configuration:
  * Added a `.github/dependabot.yml` file to enable Dependabot for GitHub Actions, scheduling monthly update checks.