### PR TITLE
refactor: Use reusable action in Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,168 +4,84 @@ on:
     release:
         types: [published]
     workflow_dispatch:
+        inputs:
+            use_cache:
+                description: Use Docker layer cache
+                type: boolean
+                default: true
+
+concurrency:
+    group: docker-publish
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+env:
+    DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+    DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
 jobs:
     # base image
     base:
         runs-on: [self-hosted, legolas]
-
-        permissions:
-            contents: read
-            packages: write
-
         steps:
-            - name: checkout
-              uses: actions/checkout@v6
-            - name: set up QEMU
-              uses: docker/setup-qemu-action@v4
-            - name: set up docker buildx
-              uses: docker/setup-buildx-action@v4
-            - name: login to Docker Hub
-              uses: docker/login-action@v4
-              with:
-                username: ${{ secrets.DOCKERHUB_USERNAME }}
-                password: ${{ secrets.DOCKERHUB_TOKEN }}
             - name: build and push
-              uses: docker/build-push-action@v6
+              uses: ./.github/actions/docker_build_push
               with:
-                context: .
-                file: ./base/Dockerfile
-                cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,mode=max
-                cache-from: type=registry,ref=brineylab/${{ github.job }}:cache
-                push: true
-                tags: |
-                    brineylab/${{ github.job }}:latest
-                    ${{ github.event_name == 'release' && format('brineylab/{0}:{1}', github.job, github.event.release.tag_name) || '' }}
+                image_name: base
+                dockerfile: ./base/Dockerfile
+                tag_name: ${{ github.event.release.tag_name }}
+                use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
 
     # datascience depends on base (adds NGS tools)
     datascience:
         runs-on: [self-hosted, legolas]
         needs: [base]
-
-        permissions:
-            contents: read
-            packages: write
-
         steps:
-            - name: checkout
-              uses: actions/checkout@v6
-            - name: set up QEMU
-              uses: docker/setup-qemu-action@v4
-            - name: set up docker buildx
-              uses: docker/setup-buildx-action@v4
-            - name: login to Docker Hub
-              uses: docker/login-action@v4
-              with:
-                username: ${{ secrets.DOCKERHUB_USERNAME }}
-                password: ${{ secrets.DOCKERHUB_TOKEN }}
             - name: build and push
-              uses: docker/build-push-action@v6
+              uses: ./.github/actions/docker_build_push
               with:
-                context: .
-                file: ./datascience/Dockerfile
-                cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,mode=max
-                cache-from: type=registry,ref=brineylab/${{ github.job }}:cache
-                push: true
-                tags: |
-                    brineylab/${{ github.job }}:latest
-                    ${{ github.event_name == 'release' && format('brineylab/{0}:{1}', github.job, github.event.release.tag_name) || '' }}
+                image_name: datascience
+                dockerfile: ./datascience/Dockerfile
+                tag_name: ${{ github.event.release.tag_name }}
+                use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
 
     # deeplearning depends on base (adds CUDA + AI/ML)
     deeplearning:
         runs-on: [self-hosted, legolas]
         needs: [base]
-
-        permissions:
-            contents: read
-            packages: write
-
         steps:
-            - name: checkout
-              uses: actions/checkout@v6
-            - name: set up QEMU
-              uses: docker/setup-qemu-action@v4
-            - name: set up docker buildx
-              uses: docker/setup-buildx-action@v4
-            - name: login to Docker Hub
-              uses: docker/login-action@v4
-              with:
-                username: ${{ secrets.DOCKERHUB_USERNAME }}
-                password: ${{ secrets.DOCKERHUB_TOKEN }}
             - name: build and push
-              uses: docker/build-push-action@v6
+              uses: ./.github/actions/docker_build_push
               with:
-                context: .
-                file: ./deeplearning/Dockerfile
-                cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,mode=max
-                cache-from: type=registry,ref=brineylab/${{ github.job }}:cache
-                push: true
-                tags: |
-                    brineylab/${{ github.job }}:latest
-                    ${{ github.event_name == 'release' && format('brineylab/{0}:{1}', github.job, github.event.release.tag_name) || '' }}
+                image_name: deeplearning
+                dockerfile: ./deeplearning/Dockerfile
+                tag_name: ${{ github.event.release.tag_name }}
+                use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
 
     # jupyterhub-datascience depends on datascience (adds JupyterLab/Hub)
     jupyterhub-datascience:
         runs-on: [self-hosted, legolas]
         needs: [datascience]
-
-        permissions:
-            contents: read
-            packages: write
-
         steps:
-            - name: checkout
-              uses: actions/checkout@v6
-            - name: set up QEMU
-              uses: docker/setup-qemu-action@v4
-            - name: set up docker buildx
-              uses: docker/setup-buildx-action@v4
-            - name: login to Docker Hub
-              uses: docker/login-action@v4
-              with:
-                username: ${{ secrets.DOCKERHUB_USERNAME }}
-                password: ${{ secrets.DOCKERHUB_TOKEN }}
             - name: build and push
-              uses: docker/build-push-action@v6
+              uses: ./.github/actions/docker_build_push
               with:
-                context: .
-                file: ./jupyterhub/datascience/Dockerfile
-                cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,mode=max
-                cache-from: type=registry,ref=brineylab/${{ github.job }}:cache
-                push: true
-                tags: |
-                    brineylab/${{ github.job }}:latest
-                    ${{ github.event_name == 'release' && format('brineylab/{0}:{1}', github.job, github.event.release.tag_name) || '' }}
+                image_name: jupyterhub-datascience
+                dockerfile: ./jupyterhub/datascience/Dockerfile
+                tag_name: ${{ github.event.release.tag_name }}
+                use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
 
     # jupyterhub-deeplearning depends on deeplearning (adds JupyterLab/Hub)
     jupyterhub-deeplearning:
         runs-on: [self-hosted, legolas]
         needs: [deeplearning]
-
-        permissions:
-            contents: read
-            packages: write
-
         steps:
-            - name: checkout
-              uses: actions/checkout@v6
-            - name: set up QEMU
-              uses: docker/setup-qemu-action@v4
-            - name: set up docker buildx
-              uses: docker/setup-buildx-action@v4
-            - name: login to Docker Hub
-              uses: docker/login-action@v4
-              with:
-                username: ${{ secrets.DOCKERHUB_USERNAME }}
-                password: ${{ secrets.DOCKERHUB_TOKEN }}
             - name: build and push
-              uses: docker/build-push-action@v6
+              uses: ./.github/actions/docker_build_push
               with:
-                context: .
-                file: ./jupyterhub/deeplearning/Dockerfile
-                cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,mode=max
-                cache-from: type=registry,ref=brineylab/${{ github.job }}:cache
-                push: true
-                tags: |
-                    brineylab/${{ github.job }}:latest
-                    ${{ github.event_name == 'release' && format('brineylab/{0}:{1}', github.job, github.event.release.tag_name) || '' }}
+                image_name: jupyterhub-deeplearning
+                dockerfile: ./jupyterhub/deeplearning/Dockerfile
+                tag_name: ${{ github.event.release.tag_name }}
+                use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}


### PR DESCRIPTION
This pull request makes significant improvements to the Docker image build and publish workflow. The main focus is on simplifying and standardizing the Docker build process by consolidating steps into a reusable action..

**CI/CD Workflow Improvements:**

* Refactored `.github/workflows/docker-publish.yml` to use a custom local action (`docker_build_push`) for building and pushing Docker images, replacing repeated inline steps and the previous use of `docker/build-push-action`. This makes the workflow more maintainable and consistent across all image builds.