### PR TITLE
refactor: introduces a reusable composite GitHub Action for building and pushing Docker images

### DIFF
--- a/.github/actions/docker_build_push/action.yml
+++ b/.github/actions/docker_build_push/action.yml
@@ -1,0 +1,59 @@
+name: Docker Build and Push
+description: Build and push a Docker image to Docker Hub
+
+inputs:
+    image_name:
+        description: Docker Hub image name (e.g. base, datascience, jupyterhub-datascience)
+        required: true
+    dockerfile:
+        description: Path to the Dockerfile
+        required: true
+    tag_name:
+        description: Release tag name (empty string on non-release triggers)
+        required: false
+        default: ''
+    use_cache:
+        description: Use Docker layer cache
+        required: false
+        default: 'true'
+
+runs:
+    using: composite
+    steps:
+        - name: checkout
+          uses: actions/checkout@v6
+          with:
+            fetch-depth: 1
+        - name: set up QEMU
+          uses: docker/setup-qemu-action@v4
+        - name: set up docker buildx
+          uses: docker/setup-buildx-action@v4
+        - name: login to Docker Hub
+          uses: docker/login-action@v4
+          with:
+            username: ${{ env.DOCKERHUB_USERNAME }}
+            password: ${{ env.DOCKERHUB_TOKEN }}
+        - name: determine tags
+          id: tags
+          shell: bash
+          run: |
+            TAGS="brineylab/${{ inputs.image_name }}:latest"
+            if [ -n "${{ inputs.tag_name }}" ]; then
+              TAGS="${TAGS}
+            brineylab/${{ inputs.image_name }}:${{ inputs.tag_name }}"
+            fi
+            echo "tags<<EOF" >> $GITHUB_OUTPUT
+            echo "$TAGS" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+        - name: build and push
+          uses: docker/build-push-action@v7
+          with:
+            context: .
+            file: ${{ inputs.dockerfile }}
+            no-cache: ${{ inputs.use_cache != 'true' }}
+            cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,mode=max
+            cache-from: type=registry,ref=brineylab/${{ github.job }}:cache
+            provenance: true
+            sbom: true
+            push: true
+            tags: ${{ steps.tags.outputs.tags }}

--- a/.github/actions/docker_build_push/action.yml
+++ b/.github/actions/docker_build_push/action.yml
@@ -20,10 +20,6 @@ inputs:
 runs:
     using: composite
     steps:
-        - name: checkout
-          uses: actions/checkout@v6
-          with:
-            fetch-depth: 1
         - name: set up QEMU
           uses: docker/setup-qemu-action@v4
         - name: set up docker buildx
@@ -54,6 +50,5 @@ runs:
             cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,mode=max
             cache-from: type=registry,ref=brineylab/${{ github.job }}:cache
             provenance: true
-            sbom: true
             push: true
             tags: ${{ steps.tags.outputs.tags }}

--- a/.github/actions/docker_build_push/action.yml
+++ b/.github/actions/docker_build_push/action.yml
@@ -16,6 +16,10 @@ inputs:
         description: Use Docker layer cache
         required: false
         default: 'true'
+    push:
+        description: Push image to Docker Hub
+        required: false
+        default: 'true'
 
 runs:
     using: composite
@@ -50,5 +54,5 @@ runs:
             cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,mode=max
             cache-from: type=registry,ref=brineylab/${{ github.job }}:cache
             provenance: true
-            push: true
+            push: ${{ inputs.push == 'true' }}
             tags: ${{ steps.tags.outputs.tags }}

--- a/.github/actions/docker_build_push/action.yml
+++ b/.github/actions/docker_build_push/action.yml
@@ -51,8 +51,8 @@ runs:
             context: .
             file: ${{ inputs.dockerfile }}
             no-cache: ${{ inputs.use_cache != 'true' }}
-            cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,mode=max
-            cache-from: type=registry,ref=brineylab/${{ github.job }}:cache
+            cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,compression=zstd,mode=min
+            cache-from: type=registry,ref=brineylab/${{ github.job }}:cache,compression=zstd
             provenance: true
             push: ${{ inputs.push == 'true' }}
             tags: ${{ steps.tags.outputs.tags }}

--- a/.github/actions/docker_build_push/action.yml
+++ b/.github/actions/docker_build_push/action.yml
@@ -51,7 +51,7 @@ runs:
             context: .
             file: ${{ inputs.dockerfile }}
             no-cache: ${{ inputs.use_cache != 'true' }}
-            cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,compression=zstd,mode=min
+            cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,compression=zstd,mode=max
             cache-from: type=registry,ref=brineylab/${{ github.job }}:cache,compression=zstd
             provenance: true
             push: ${{ inputs.push == 'true' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,10 @@ on:
                 description: Use Docker layer cache
                 type: boolean
                 default: true
+            push:
+                description: Push image to Docker Hub
+                type: boolean
+                default: true
 
 concurrency:
     group: docker-publish
@@ -37,6 +41,7 @@ jobs:
                 dockerfile: ./base/Dockerfile
                 tag_name: ${{ github.event.release.tag_name }}
                 use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
+                push: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}
 
     # datascience depends on base (adds NGS tools)
     datascience:
@@ -54,6 +59,7 @@ jobs:
                 dockerfile: ./datascience/Dockerfile
                 tag_name: ${{ github.event.release.tag_name }}
                 use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
+                push: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}
 
     # deeplearning depends on base (adds CUDA + AI/ML)
     deeplearning:
@@ -71,6 +77,7 @@ jobs:
                 dockerfile: ./deeplearning/Dockerfile
                 tag_name: ${{ github.event.release.tag_name }}
                 use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
+                push: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}
 
     # jupyterhub-datascience depends on datascience (adds JupyterLab/Hub)
     jupyterhub-datascience:
@@ -88,6 +95,7 @@ jobs:
                 dockerfile: ./jupyterhub/datascience/Dockerfile
                 tag_name: ${{ github.event.release.tag_name }}
                 use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
+                push: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}
 
     # jupyterhub-deeplearning depends on deeplearning (adds JupyterLab/Hub)
     jupyterhub-deeplearning:
@@ -105,3 +113,4 @@ jobs:
                 dockerfile: ./jupyterhub/deeplearning/Dockerfile
                 tag_name: ${{ github.event.release.tag_name }}
                 use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
+                push: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,6 +26,10 @@ jobs:
     base:
         runs-on: [self-hosted, legolas]
         steps:
+            - name: checkout
+              uses: actions/checkout@v6
+              with:
+                fetch-depth: 1
             - name: build and push
               uses: ./.github/actions/docker_build_push
               with:
@@ -39,6 +43,10 @@ jobs:
         runs-on: [self-hosted, legolas]
         needs: [base]
         steps:
+            - name: checkout
+              uses: actions/checkout@v6
+              with:
+                fetch-depth: 1
             - name: build and push
               uses: ./.github/actions/docker_build_push
               with:
@@ -52,6 +60,10 @@ jobs:
         runs-on: [self-hosted, legolas]
         needs: [base]
         steps:
+            - name: checkout
+              uses: actions/checkout@v6
+              with:
+                fetch-depth: 1
             - name: build and push
               uses: ./.github/actions/docker_build_push
               with:
@@ -65,6 +77,10 @@ jobs:
         runs-on: [self-hosted, legolas]
         needs: [datascience]
         steps:
+            - name: checkout
+              uses: actions/checkout@v6
+              with:
+                fetch-depth: 1
             - name: build and push
               uses: ./.github/actions/docker_build_push
               with:
@@ -78,6 +94,10 @@ jobs:
         runs-on: [self-hosted, legolas]
         needs: [deeplearning]
         steps:
+            - name: checkout
+              uses: actions/checkout@v6
+              with:
+                fetch-depth: 1
             - name: build and push
               uses: ./.github/actions/docker_build_push
               with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,168 +4,84 @@ on:
     release:
         types: [published]
     workflow_dispatch:
+        inputs:
+            use_cache:
+                description: Use Docker layer cache
+                type: boolean
+                default: true
+
+concurrency:
+    group: docker-publish
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+env:
+    DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+    DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
 jobs:
     # base image
     base:
         runs-on: [self-hosted, legolas]
-
-        permissions:
-            contents: read
-            packages: write
-
         steps:
-            - name: checkout
-              uses: actions/checkout@v6
-            - name: set up QEMU
-              uses: docker/setup-qemu-action@v4
-            - name: set up docker buildx
-              uses: docker/setup-buildx-action@v4
-            - name: login to Docker Hub
-              uses: docker/login-action@v4
-              with:
-                username: ${{ secrets.DOCKERHUB_USERNAME }}
-                password: ${{ secrets.DOCKERHUB_TOKEN }}
             - name: build and push
-              uses: docker/build-push-action@v6
+              uses: ./.github/actions/docker_build_push
               with:
-                context: .
-                file: ./base/Dockerfile
-                cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,mode=max
-                cache-from: type=registry,ref=brineylab/${{ github.job }}:cache
-                push: true
-                tags: |
-                    brineylab/${{ github.job }}:latest
-                    ${{ github.event_name == 'release' && format('brineylab/{0}:{1}', github.job, github.event.release.tag_name) || '' }}
+                image_name: base
+                dockerfile: ./base/Dockerfile
+                tag_name: ${{ github.event.release.tag_name }}
+                use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
 
     # datascience depends on base (adds NGS tools)
     datascience:
         runs-on: [self-hosted, legolas]
         needs: [base]
-
-        permissions:
-            contents: read
-            packages: write
-
         steps:
-            - name: checkout
-              uses: actions/checkout@v6
-            - name: set up QEMU
-              uses: docker/setup-qemu-action@v4
-            - name: set up docker buildx
-              uses: docker/setup-buildx-action@v4
-            - name: login to Docker Hub
-              uses: docker/login-action@v4
-              with:
-                username: ${{ secrets.DOCKERHUB_USERNAME }}
-                password: ${{ secrets.DOCKERHUB_TOKEN }}
             - name: build and push
-              uses: docker/build-push-action@v6
+              uses: ./.github/actions/docker_build_push
               with:
-                context: .
-                file: ./datascience/Dockerfile
-                cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,mode=max
-                cache-from: type=registry,ref=brineylab/${{ github.job }}:cache
-                push: true
-                tags: |
-                    brineylab/${{ github.job }}:latest
-                    ${{ github.event_name == 'release' && format('brineylab/{0}:{1}', github.job, github.event.release.tag_name) || '' }}
+                image_name: datascience
+                dockerfile: ./datascience/Dockerfile
+                tag_name: ${{ github.event.release.tag_name }}
+                use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
 
     # deeplearning depends on base (adds CUDA + AI/ML)
     deeplearning:
         runs-on: [self-hosted, legolas]
         needs: [base]
-
-        permissions:
-            contents: read
-            packages: write
-
         steps:
-            - name: checkout
-              uses: actions/checkout@v6
-            - name: set up QEMU
-              uses: docker/setup-qemu-action@v4
-            - name: set up docker buildx
-              uses: docker/setup-buildx-action@v4
-            - name: login to Docker Hub
-              uses: docker/login-action@v4
-              with:
-                username: ${{ secrets.DOCKERHUB_USERNAME }}
-                password: ${{ secrets.DOCKERHUB_TOKEN }}
             - name: build and push
-              uses: docker/build-push-action@v6
+              uses: ./.github/actions/docker_build_push
               with:
-                context: .
-                file: ./deeplearning/Dockerfile
-                cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,mode=max
-                cache-from: type=registry,ref=brineylab/${{ github.job }}:cache
-                push: true
-                tags: |
-                    brineylab/${{ github.job }}:latest
-                    ${{ github.event_name == 'release' && format('brineylab/{0}:{1}', github.job, github.event.release.tag_name) || '' }}
+                image_name: deeplearning
+                dockerfile: ./deeplearning/Dockerfile
+                tag_name: ${{ github.event.release.tag_name }}
+                use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
 
     # jupyterhub-datascience depends on datascience (adds JupyterLab/Hub)
     jupyterhub-datascience:
         runs-on: [self-hosted, legolas]
         needs: [datascience]
-
-        permissions:
-            contents: read
-            packages: write
-
         steps:
-            - name: checkout
-              uses: actions/checkout@v6
-            - name: set up QEMU
-              uses: docker/setup-qemu-action@v4
-            - name: set up docker buildx
-              uses: docker/setup-buildx-action@v4
-            - name: login to Docker Hub
-              uses: docker/login-action@v4
-              with:
-                username: ${{ secrets.DOCKERHUB_USERNAME }}
-                password: ${{ secrets.DOCKERHUB_TOKEN }}
             - name: build and push
-              uses: docker/build-push-action@v6
+              uses: ./.github/actions/docker_build_push
               with:
-                context: .
-                file: ./jupyterhub/datascience/Dockerfile
-                cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,mode=max
-                cache-from: type=registry,ref=brineylab/${{ github.job }}:cache
-                push: true
-                tags: |
-                    brineylab/${{ github.job }}:latest
-                    ${{ github.event_name == 'release' && format('brineylab/{0}:{1}', github.job, github.event.release.tag_name) || '' }}
+                image_name: jupyterhub-datascience
+                dockerfile: ./jupyterhub/datascience/Dockerfile
+                tag_name: ${{ github.event.release.tag_name }}
+                use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
 
     # jupyterhub-deeplearning depends on deeplearning (adds JupyterLab/Hub)
     jupyterhub-deeplearning:
         runs-on: [self-hosted, legolas]
         needs: [deeplearning]
-
-        permissions:
-            contents: read
-            packages: write
-
         steps:
-            - name: checkout
-              uses: actions/checkout@v6
-            - name: set up QEMU
-              uses: docker/setup-qemu-action@v4
-            - name: set up docker buildx
-              uses: docker/setup-buildx-action@v4
-            - name: login to Docker Hub
-              uses: docker/login-action@v4
-              with:
-                username: ${{ secrets.DOCKERHUB_USERNAME }}
-                password: ${{ secrets.DOCKERHUB_TOKEN }}
             - name: build and push
-              uses: docker/build-push-action@v6
+              uses: ./.github/actions/docker_build_push
               with:
-                context: .
-                file: ./jupyterhub/deeplearning/Dockerfile
-                cache-to: type=registry,ref=brineylab/${{ github.job }}:cache,mode=max
-                cache-from: type=registry,ref=brineylab/${{ github.job }}:cache
-                push: true
-                tags: |
-                    brineylab/${{ github.job }}:latest
-                    ${{ github.event_name == 'release' && format('brineylab/{0}:{1}', github.job, github.event.release.tag_name) || '' }}
+                image_name: jupyterhub-deeplearning
+                dockerfile: ./jupyterhub/deeplearning/Dockerfile
+                tag_name: ${{ github.event.release.tag_name }}
+                use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}

--- a/datascience/Dockerfile
+++ b/datascience/Dockerfile
@@ -128,7 +128,6 @@ RUN python3 -m pip install --no-cache-dir \
     && fix-permissions "/home/${NB_USER}"
 
 RUN cd "${NGS_TOOLS_DIR}/igdiscover22" \
-    && git config --global --add safe.directory ${NGS_TOOLS_DIR}/igdiscover22
     && mamba create -f environment_no-default.yml -n igdiscover \
     && mamba run -n igdiscover python3 -m pip install --no-cache-dir --no-deps -e . \
     && mamba run -n igdiscover python3 -m pip install --no-cache-dir "networkx==2.1" \

--- a/datascience/Dockerfile
+++ b/datascience/Dockerfile
@@ -128,6 +128,7 @@ RUN python3 -m pip install --no-cache-dir \
     && fix-permissions "/home/${NB_USER}"
 
 RUN cd "${NGS_TOOLS_DIR}/igdiscover22" \
+    && git config --global --add safe.directory ${NGS_TOOLS_DIR}/igdiscover22
     && mamba create -f environment_no-default.yml -n igdiscover \
     && mamba run -n igdiscover python3 -m pip install --no-cache-dir --no-deps -e . \
     && mamba run -n igdiscover python3 -m pip install --no-cache-dir "networkx==2.1" \


### PR DESCRIPTION
This pull request refactors the Docker image build and publish workflow to improve maintainability and flexibility. It introduces a reusable composite GitHub Action for building and pushing Docker images, and updates the workflow to use this action for all image jobs. Additionally, it adds support for configurable cache and push options via workflow dispatch inputs, and streamlines permissions and environment variable handling.

Key changes:

**Reusable Docker build/push action:**
* Adds a new composite action at `.github/actions/docker_build_push/action.yml` to encapsulate all steps required for building and pushing Docker images, including QEMU setup, buildx setup, Docker Hub login, dynamic tag calculation, and cache management.