### PR TITLE
feat: add base and jupyterhub-base images, and gh CLI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,7 +31,7 @@ jobs:
         runs-on: ubuntu-latest-brineylab-xlarge
         steps:
             - name: checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@v7
               with:
                 fetch-depth: 1
             - name: build and push
@@ -83,7 +83,7 @@ jobs:
         needs: [base]
         steps:
             - name: checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@v7
               with:
                 fetch-depth: 1
             - name: build and push

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,6 +26,23 @@ env:
     DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
 jobs:
+    # base
+    base:
+        runs-on: ubuntu-latest-brineylab-xlarge
+        steps:
+            - name: checkout
+              uses: actions/checkout@v6
+              with:
+                fetch-depth: 1
+            - name: build and push
+              uses: ./.github/actions/docker_build_push
+              with:
+                image_name: base
+                dockerfile: ./base/Dockerfile
+                tag_name: ${{ github.event.release.tag_name }}
+                use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
+                push: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}
+
     # datascience
     datascience:
         runs-on: ubuntu-latest-brineylab-xlarge
@@ -56,6 +73,24 @@ jobs:
               with:
                 image_name: deeplearning
                 dockerfile: ./deeplearning/Dockerfile
+                tag_name: ${{ github.event.release.tag_name }}
+                use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
+                push: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}
+
+    # jupyterhub-base depends on base (adds JupyterLab/Hub)
+    jupyterhub-base:
+        runs-on: ubuntu-latest
+        needs: [base]
+        steps:
+            - name: checkout
+              uses: actions/checkout@v6
+              with:
+                fetch-depth: 1
+            - name: build and push
+              uses: ./.github/actions/docker_build_push
+              with:
+                image_name: jupyterhub-base
+                dockerfile: ./jupyterhub/base/Dockerfile
                 tag_name: ${{ github.event.release.tag_name }}
                 use_cache: ${{ github.event_name != 'workflow_dispatch' || inputs.use_cache }}
                 push: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}

--- a/README.md
+++ b/README.md
@@ -9,26 +9,28 @@ tagged with both the release tag and `latest`.
 
 | Image | Built on | Contents |
 |---|---|---|
-| `brineylab/base` | NVIDIA CUDA DL Base | OS tooling, Python, conda/mamba, uv, s5cmd. No scientific, AI/ML, or R packages. |
+| `brineylab/base` | NVIDIA CUDA DL Base | OS tooling, the Python and R interpreters, conda/mamba, uv, s5cmd. No scientific, AI/ML, or R libraries. |
 | `brineylab/datascience` | `ubuntu:24.04` | Scientific Python, R, and the NGS toolchain (CellRanger, dorado, IgDiscover, ...). |
 | `brineylab/deeplearning` | NVIDIA CUDA DL Base | Everything in datascience minus NGS tools, plus PyTorch, JAX, HuggingFace, DeepSpeed, and flash-attn. |
-| `brineylab/jupyterhub-base` | `brineylab/base` | Adds JupyterLab, Notebook, and JupyterHub. |
+| `brineylab/jupyterhub-base` | `brineylab/base` | Adds JupyterLab, Notebook, JupyterHub, and the R kernel. |
 | `brineylab/jupyterhub-datascience` | `brineylab/datascience` | Adds JupyterLab, Notebook, and JupyterHub. |
 | `brineylab/jupyterhub-deeplearning` | `brineylab/deeplearning` | Adds JupyterLab, Notebook, JupyterHub, and the GPU dashboard. |
 
 The `base` images build on NVIDIA's CUDA image but contain no driver, so they run
-on CPU-only hosts as well; the CUDA libraries are simply unused. They provide a
-Python kernel only, since R is not installed.
+on CPU-only hosts as well; the CUDA libraries are simply unused.
 
 ## Rolling your own environment
 
-`base` exists so you can install your own packages rather than inherit ours:
+`base` exists so you can install your own packages rather than inherit ours. It
+ships the Python and R interpreters and their package managers, but no libraries:
 
 ```dockerfile
 FROM brineylab/base
 
 COPY requirements.txt /tmp/requirements.txt
 RUN uv pip install --no-cache --system -r /tmp/requirements.txt
+
+RUN Rscript -e "install.packages('data.table', repos = 'https://cran.rstudio.com')"
 ```
 
 Or create a separate conda environment at runtime with `mamba create -n myenv ...`.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # containers
- 
+
+Docker images maintained by the Briney Lab, published to Docker Hub under
+[`brineylab`](https://hub.docker.com/u/brineylab). Images are built and pushed by
+[`docker-publish.yml`](.github/workflows/docker-publish.yml) on each GitHub release,
+tagged with both the release tag and `latest`.
+
+## Images
+
+| Image | Built on | Contents |
+|---|---|---|
+| `brineylab/base` | NVIDIA CUDA DL Base | OS tooling, Python, conda/mamba, uv, s5cmd. No scientific, AI/ML, or R packages. |
+| `brineylab/datascience` | `ubuntu:24.04` | Scientific Python, R, and the NGS toolchain (CellRanger, dorado, IgDiscover, ...). |
+| `brineylab/deeplearning` | NVIDIA CUDA DL Base | Everything in datascience minus NGS tools, plus PyTorch, JAX, HuggingFace, DeepSpeed, and flash-attn. |
+| `brineylab/jupyterhub-base` | `brineylab/base` | Adds JupyterLab, Notebook, and JupyterHub. |
+| `brineylab/jupyterhub-datascience` | `brineylab/datascience` | Adds JupyterLab, Notebook, and JupyterHub. |
+| `brineylab/jupyterhub-deeplearning` | `brineylab/deeplearning` | Adds JupyterLab, Notebook, JupyterHub, and the GPU dashboard. |
+
+The `base` images build on NVIDIA's CUDA image but contain no driver, so they run
+on CPU-only hosts as well; the CUDA libraries are simply unused. They provide a
+Python kernel only, since R is not installed.
+
+## Rolling your own environment
+
+`base` exists so you can install your own packages rather than inherit ours:
+
+```dockerfile
+FROM brineylab/base
+
+COPY requirements.txt /tmp/requirements.txt
+RUN uv pip install --no-cache --system -r /tmp/requirements.txt
+```
+
+Or create a separate conda environment at runtime with `mamba create -n myenv ...`.
+
+## Package lists
+
+Packages live in [`requirements/`](requirements) rather than in the Dockerfiles:
+
+- `apt.txt` — OS packages, used by every image
+- `pip.txt` — scientific and biology Python packages (datascience, deeplearning)
+- `ai-ml_pip.txt` — AI/ML packages (deeplearning only)
+- `r_conda.txt` / `r_cran.txt` — R packages (datascience, deeplearning)
+- `jupyter_pip.txt` — Jupyter packages (`jupyterhub-*` images only)

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,7 +8,8 @@
 # https://en.wikipedia.org/wiki/BSD_licenses#3-clause_license
 
 # A minimal environment for users who manage their own packages: OS tooling,
-# Python, conda/mamba, uv, and s5cmd -- but no scientific, AI/ML, or R packages.
+# the Python and R interpreters, conda/mamba, uv, and s5cmd -- but none of the
+# scientific, AI/ML, or R libraries carried by the datascience/deeplearning images.
 
 # NVIDIA CUDA DL Base provides CUDA, cuDNN, NCCL, and TensorRT without Python.
 # The image carries no driver (that is injected at runtime by the NVIDIA container
@@ -74,6 +75,7 @@ RUN set -x \
         "python=${PYTHON_VERSION}" \
         'conda' \
         'mamba' \
+        'r-base' \
     && rm -rf /tmp/bin/ \
     && mamba list --full-name 'python' | awk 'END{sub("[^.]*$", "*", $2); print $1 " " $2}' >> "${CONDA_DIR}/conda-meta/pinned" \
     && mamba clean --all -f -y \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,0 +1,117 @@
+# This image was initially created by the Jupyter Development Team:
+# https://github.com/jupyter/docker-stacks
+# and was subsequently modified and maintained by the Briney Lab.
+
+# In alignment with the licensing of the orignal image created
+# by the Jupyter Development Team, this image is distributed
+# under the terms of the Modified BSD License.
+# https://en.wikipedia.org/wiki/BSD_licenses#3-clause_license
+
+# A minimal environment for users who manage their own packages: OS tooling,
+# Python, conda/mamba, uv, and s5cmd -- but no scientific, AI/ML, or R packages.
+
+# NVIDIA CUDA DL Base provides CUDA, cuDNN, NCCL, and TensorRT without Python.
+# The image carries no driver (that is injected at runtime by the NVIDIA container
+# toolkit), so it also runs on CPU-only hosts with the CUDA libraries simply unused.
+# Keep this tag in sync with deeplearning/Dockerfile, which is pinned to CUDA 13.0
+# to match the driver version on our servers.
+ARG BASE_IMG=nvcr.io/nvidia/cuda-dl-base:25.11-cuda13.0-devel-ubuntu24.04
+FROM $BASE_IMG
+
+LABEL maintainer='Briney Lab @ Scripps Research <briney@scripps.edu>'
+
+# Python version
+ARG PYTHON_VERSION=3.12
+
+# Environmental variables
+ENV DEBIAN_FRONTEND=noninteractive \
+    CONDA_DIR=/opt/conda \
+    SHELL=/bin/bash \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
+ENV PATH="${CONDA_DIR}/bin:${PATH}"
+
+# NVIDIA configs
+ENV NVIDIA_VISIBLE_DEVICES='all'
+ENV NVIDIA_DRIVER_CAPABILITIES='compute,utility'
+
+# Fix: https://github.com/hadolint/hadolint/wiki/DL4006
+# Fix: https://github.com/koalaman/shellcheck/wiki/SC3014
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+
+# ----------------------------
+#       OS dependencies
+# ----------------------------
+COPY ./requirements/apt.txt /tmp/apt.txt
+RUN apt-get update --yes \
+    && apt-get upgrade --yes \
+    && apt-get install --yes --no-install-recommends \
+        $(grep -v '^\s*#' /tmp/apt.txt | grep -v '^\s*$') \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+    && locale-gen
+
+
+# ----------------------------
+#         Micromamba
+# ----------------------------
+COPY ./common/initial-condarc "${CONDA_DIR}/.condarc"
+WORKDIR /tmp
+RUN set -x \
+    && arch=$(uname -m) \
+    && if [ "${arch}" = "x86_64" ]; then \
+        arch="64"; \
+    fi \
+    && wget --progress=dot:giga -O - \
+        "https://micro.mamba.pm/api/micromamba/linux-${arch}/latest" | tar -xvj bin/micromamba \
+    && ./bin/micromamba install \
+        --root-prefix="${CONDA_DIR}" \
+        --prefix="${CONDA_DIR}" \
+        --yes \
+        "python=${PYTHON_VERSION}" \
+        'conda' \
+        'mamba' \
+    && rm -rf /tmp/bin/ \
+    && mamba list --full-name 'python' | awk 'END{sub("[^.]*$", "*", $2); print $1 " " $2}' >> "${CONDA_DIR}/conda-meta/pinned" \
+    && mamba clean --all -f -y \
+    # move conda compiler_compat/ld to force use of system linker (fixes deepspeed JIT compilation)
+    # ref: https://github.com/ContinuumIO/anaconda-issues/issues/11152
+    && mv "${CONDA_DIR}/compiler_compat/ld" "${CONDA_DIR}/compiler_compat/ld.bak"
+
+# Mamba shell hook for interactive sessions, with base activation
+# Set umask to 000
+RUN echo 'eval "$(mamba shell hook --shell bash)"' >> /etc/bash.bashrc \
+    && echo 'mamba activate base' >> /etc/bash.bashrc \
+    && echo 'umask 000' >> /etc/bash.bashrc
+
+
+# ----------------------------
+#             uv
+# ----------------------------
+RUN python3 -m pip install --no-cache-dir uv
+
+
+# ----------------------------
+#    s5cmd (CoreWeave fork)
+# ----------------------------
+ARG S5CMD_VERSION=2.3.0-acb67716
+RUN wget -q "https://github.com/coreweave/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_linux_amd64.deb" \
+    && apt-get update --yes \
+    && apt-get install --yes --no-install-recommends "./s5cmd_${S5CMD_VERSION}_linux_amd64.deb" \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm "s5cmd_${S5CMD_VERSION}_linux_amd64.deb"
+
+
+# ----------------------------
+#         Final Setup
+# ----------------------------
+ENV HOME=/home/jovyan
+RUN mkdir -p /home/jovyan
+WORKDIR /home/jovyan
+
+ENTRYPOINT ["tini", "--"]
+CMD ["/bin/bash"]

--- a/jupyterhub/base/Dockerfile
+++ b/jupyterhub/base/Dockerfile
@@ -1,0 +1,58 @@
+ARG OWNER=brineylab
+ARG BASE_IMG=$OWNER/base
+FROM $BASE_IMG
+
+# This image was initially created by the Jupyter Development Team:
+# https://github.com/jupyter/docker-stacks
+# and was subsequently modified and maintained by the Briney Lab.
+LABEL maintainer='Briney Lab @ Scripps Research <briney@scripps.edu>'
+
+# In alignment with the licensing of the orignal image created
+# by the Jupyter Development Team, this image is distributed
+# under the terms of the Modified BSD License.
+# https://en.wikipedia.org/wiki/BSD_licenses#3-clause_license
+
+# Runtime config
+ENV PIP_NO_CACHE_DIR=1 \
+    JUPYTER_PORT=8888
+EXPOSE $JUPYTER_PORT
+
+
+# ----------------------------
+#      Jupyter Packages
+# ----------------------------
+# installs JupyterLab, Jupyter Notebook, and JupyterHub
+# generates a Jupyter Server config
+WORKDIR /tmp
+
+# nodejs is required for JupyterLab extension building
+RUN mamba install --yes 'nodejs>=20.0.0' \
+    && mamba clean --all -f -y
+
+COPY ./requirements/jupyter_pip.txt /tmp/jupyter_pip.txt
+RUN uv pip install --no-cache --system -r /tmp/jupyter_pip.txt \
+    && jupyter server --generate-config \
+    && jupyter lab clean \
+    && npm cache clean --force
+
+
+# ----------------------------
+#    Container Startup
+# ----------------------------
+COPY ./jupyterhub/runtime/start-notebook.py ./jupyterhub/runtime/start-singleuser.py /usr/local/bin/
+COPY ./jupyterhub/runtime/jupyter_server_config.py ./jupyterhub/runtime/docker_healthcheck.py /etc/jupyter/
+
+HEALTHCHECK --interval=3s --timeout=1s --start-period=3s --retries=3 \
+    CMD /etc/jupyter/docker_healthcheck.py || exit 1
+
+# No Rprofile.site here: unlike the datascience and deeplearning images, base has
+# no R installed, so this image provides a Python kernel only.
+
+
+# ----------------------------
+#         Final Setup
+# ----------------------------
+WORKDIR /home/jovyan
+
+ENTRYPOINT ["tini", "--"]
+CMD ["start-notebook.py"]

--- a/jupyterhub/base/Dockerfile
+++ b/jupyterhub/base/Dockerfile
@@ -26,7 +26,8 @@ EXPOSE $JUPYTER_PORT
 WORKDIR /tmp
 
 # nodejs is required for JupyterLab extension building
-RUN mamba install --yes 'nodejs>=20.0.0' \
+# r-irkernel provides the R kernel (base installs r-base, but no R packages)
+RUN mamba install --yes 'nodejs>=20.0.0' 'r-irkernel' \
     && mamba clean --all -f -y
 
 COPY ./requirements/jupyter_pip.txt /tmp/jupyter_pip.txt
@@ -45,8 +46,8 @@ COPY ./jupyterhub/runtime/jupyter_server_config.py ./jupyterhub/runtime/docker_h
 HEALTHCHECK --interval=3s --timeout=1s --start-period=3s --retries=3 \
     CMD /etc/jupyter/docker_healthcheck.py || exit 1
 
-# No Rprofile.site here: unlike the datascience and deeplearning images, base has
-# no R installed, so this image provides a Python kernel only.
+# Add R mimetype option to specify how the plot returns from R to the browser
+COPY ./jupyterhub/runtime/Rprofile.site /opt/conda/lib/R/etc/
 
 
 # ----------------------------

--- a/requirements/apt.txt
+++ b/requirements/apt.txt
@@ -12,6 +12,7 @@ fonts-dejavu
 fonts-liberation
 gcc
 gfortran
+gh
 git
 gnupg2
 htop


### PR DESCRIPTION
Adds the GitHub CLI to every image, plus two minimal images for people who
manage their own environments.

**gh** — one line in `requirements/apt.txt`, so it reaches all six images with
no Dockerfile changes. Ubuntu ships 2.45.0 in `noble-updates/universe`.

**base / jupyterhub-base** — OS tooling, the Python and R interpreters,
conda/mamba, uv, and s5cmd, but none of the libraries the datascience and
deeplearning images carry. `jupyterhub-base` adds JupyterLab/Hub and both
kernels on top.

Three things worth knowing:

- These are standalone leaves, **not** a revival of the shared base removed in
  #51. `datascience` and `deeplearning` are untouched, so there's no regression
  risk and CI stays parallel. Cost: the OS+mamba block is now duplicated in
  three Dockerfiles.
- `base` uses the same `cuda-dl-base:25.11-cuda13.0` tag as `deeplearning` (the
  deliberate pin from a8f0db8). It carries no driver, so it runs fine on
  CPU-only hosts.
- R means `r-base` only, not `r_conda.txt` — the interpreter and
  `install.packages`, none of tidyverse/tidymodels/caret/shiny. Same treatment
  Python gets. Costs ~1.3 GB uncompressed.

Tested by local build (no suite on `main`): both images build clean; base has
the expected tools and none of the excluded Python or R libraries; and
`jupyterhub-base` passes its healthcheck, serves `/lab` and `/api`, and
executes code in both the Python and R kernels.