### PR TITLE
fix: CPU torch in datascience, add HMMER, pin r-base

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -75,7 +75,7 @@ RUN set -x \
         "python=${PYTHON_VERSION}" \
         'conda' \
         'mamba' \
-        'r-base' \
+        'r-base=4.5.*' \
     && rm -rf /tmp/bin/ \
     && mamba list --full-name 'python' | awk 'END{sub("[^.]*$", "*", $2); print $1 " " $2}' >> "${CONDA_DIR}/conda-meta/pinned" \
     && mamba clean --all -f -y \

--- a/images/datascience/Dockerfile
+++ b/images/datascience/Dockerfile
@@ -87,7 +87,7 @@ RUN mamba install --yes --file /tmp/r_conda.txt \
 RUN python3 -m pip install --no-cache-dir uv
 
 COPY ./requirements/pip.txt /tmp/pip.txt
-RUN uv pip install --no-cache --system -r /tmp/pip.txt
+RUN uv pip install --no-cache --system --torch-backend=cpu -r /tmp/pip.txt
 
 
 # ----------------------------

--- a/requirements/apt.txt
+++ b/requirements/apt.txt
@@ -15,6 +15,7 @@ gfortran
 gh
 git
 gnupg2
+hmmer
 htop
 less
 libaio-dev

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -221,16 +221,12 @@ print('POSITIONS', len(res['numbering']))
         assert result.returncode == 0, f"anarcii numbering failed: {result.stdout}"
         assert "POSITIONS 128" in result.stdout, result.stdout
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Known issue: abnumber delegates to classic anarci, which shells out "
-            "to hmmscan, but HMMER is not in apt.txt. Both packages import fine "
-            "and fail at runtime. Add 'hmmer' to requirements/apt.txt to fix, "
-            "then remove this marker."
-        ),
-    )
     def test_abnumber_numbers_real_antibody(self, stack_image):
+        """abnumber delegates to classic anarci, which shells out to hmmscan.
+
+        Both packages import cleanly without HMMER present and only fail at
+        runtime, so an import test is not enough here.
+        """
         script = f"""
 from abnumber import Chain
 ch = Chain('{self.TRASTUZUMAB_VH}', scheme='imgt')

--- a/tests/test_base_images.py
+++ b/tests/test_base_images.py
@@ -67,3 +67,25 @@ class TestBaseHasNoJupyter:
         tag = request.config.getoption("--tag")
         result = docker_run(f"brineylab/base:{tag}", "which jupyter")
         assert result.returncode != 0, "jupyter should only be in the jupyterhub images"
+
+
+class TestRVersionParity:
+    """base and jupyterhub-base must agree on R.
+
+    r-irkernel is built against a specific R minor version (build string r45),
+    so installing it in the jupyterhub layer silently downgraded r-base. Pinning
+    r-base in the base image keeps the two in step and stops a user's first
+    `mamba install r-<pkg>` from pulling R out from under them.
+    """
+
+    def test_r_version_matches_across_base_images(self, request):
+        tag = request.config.getoption("--tag")
+        cmd = "Rscript -e 'cat(paste(R.version$major, R.version$minor, sep=\".\"))'"
+        base = docker_run(f"brineylab/base:{tag}", cmd)
+        jh = docker_run(f"brineylab/jupyterhub-base:{tag}", cmd)
+        assert base.returncode == 0, base.stdout
+        assert jh.returncode == 0, jh.stdout
+        assert base.stdout.strip() == jh.stdout.strip(), (
+            f"R differs: base={base.stdout.strip()} "
+            f"jupyterhub-base={jh.stdout.strip()}"
+        )

--- a/tests/test_datascience.py
+++ b/tests/test_datascience.py
@@ -86,18 +86,13 @@ class TestExcludedPackages:
         assert result.returncode != 0, \
             f"{module} should not be in the datascience image, but imported successfully"
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Known issue: pip.txt -> abnumber -> anarcii pulls torch, and pip "
-            "resolves the default CUDA wheel. That puts ~1.1 GB of torch plus "
-            "~2.7 GB of nvidia/* CUDA libraries into the CPU-only image. Fix is "
-            "to install torch from the PyTorch CPU index in this image. Remove "
-            "this marker once that lands."
-        ),
-    )
     def test_torch_is_cpu_build_if_present(self, image):
-        """datascience runs on CPU nodes, so any torch here should be the CPU wheel."""
+        """datascience runs on CPU nodes, so any torch here should be the CPU wheel.
+
+        torch arrives transitively via abnumber -> anarcii. Without
+        --torch-backend=cpu on the pip.txt install, pip resolves the default
+        CUDA wheel and drags ~2.7 GB of nvidia/* libraries in with it.
+        """
         result = docker_run(image, "python3 -c 'import torch; print(torch.__version__)'")
         if result.returncode != 0:
             pytest.skip("torch not installed, nothing to check")


### PR DESCRIPTION
Rebased onto `main` after #59 was squash-merged; now a single commit targeting
`main`.

Three defects the test suite surfaced. Each one's assertion is either newly
added here or had its `strict` xfail marker removed in the same commit — a
strict xfail that starts passing is itself a failure, so fix and marker have to
move together.

## 1. datascience shipped a CUDA torch build

`torch` arrives transitively through `pip.txt` → `abnumber` → `anarcii`, and pip
resolves the default wheel — putting ~1.1 GB of torch plus ~2.7 GB of `nvidia/*`
CUDA libraries into the CPU-only image.

```diff
- RUN uv pip install --no-cache --system -r /tmp/pip.txt
+ RUN uv pip install --no-cache --system --torch-backend=cpu -r /tmp/pip.txt
```

`--torch-backend` redirects only the PyTorch ecosystem and leaves everything
else on PyPI. **`deeplearning` deliberately keeps the unflagged install**, since
it wants `cu130`. Use `cpu` rather than `auto` — `auto` probes the build
machine's driver, and CI builders have no GPU.

Verified: `torch 2.13.0+cpu`, `nvidia/` absent, **18 GB → 14.1 GB** uncompressed,
and ANARCII numbering of trastuzumab VH byte-identical to the CUDA build.

Approaches that do not work, for the record: the CPU `--index-url` plus
`--extra-index-url` for PyPI silently installs the CUDA wheel anyway (uv searches
extra indexes first and considers only the first index carrying a package, as a
dependency-confusion guard); pinning `torch==2.13.0+cpu` alongside both indexes
fails outright with `No solution found`.

## 2. anarci and abnumber could not number a sequence

Classic `anarci` shells out to `hmmscan`, and **HMMER was in neither `apt.txt`
nor any requirements file**. Both packages imported cleanly and failed only at
runtime — exactly what an import-only test cannot catch. Added `hmmer`;
`abnumber` now numbers trastuzumab VH against HMMER 3.4.

## 3. base and jupyterhub-base disagreed on R

`base` shipped R 4.6.1 while `jupyterhub-base` shipped 4.5.3, because
`r-irkernel` is built against R 4.5 (build string `r45`) and silently downgraded
`r-base` in the jupyterhub layer. That also meant a user's first
`mamba install r-<pkg>` in `base` would move R underneath them. Pinned
`r-base=4.5.*`; both now report 4.5.3. The parity test was written first and
observed failing before the pin.

## Verification

Rebuilt `base`, `jupyterhub-base` and `datascience` locally:

- 106 passed across `test_base.py` + `test_datascience.py`
- 32 passed in `test_base_images.py`, including the new R parity test
- 22 passed in the jupyterhub suite

**`deeplearning` was not rebuilt locally** (~2h build). Its only change here is
the shared `hmmer` addition, exercised through `datascience`; CI will cover it.