### PR TITLE
fix: do not abort test collection when nvidia-smi is absent

### DIFF
--- a/tests/test_deeplearning.py
+++ b/tests/test_deeplearning.py
@@ -14,8 +14,18 @@ def image(request):
 
 
 def _gpu_available() -> bool:
-    """Check if GPU is available on the host."""
-    result = subprocess.run(["nvidia-smi"], capture_output=True)
+    """Whether the host has a usable GPU.
+
+    subprocess.run raises OSError (FileNotFoundError) when nvidia-smi is absent
+    rather than returning non-zero. This runs at collection time inside a
+    skipif decorator, so an unhandled raise aborts collection of the whole file
+    and the suite reports an error without running a single test. CI runners
+    have no nvidia-smi at all, which is exactly that case.
+    """
+    try:
+        result = subprocess.run(["nvidia-smi"], capture_output=True)
+    except OSError:
+        return False
     return result.returncode == 0
 
 


### PR DESCRIPTION
The first CI run of the test suite (run 30413023684) failed. All six image
builds succeeded; the `test` job errored **without executing a single test**.

```
tests/test_deeplearning.py:18: in _gpu_available
    result = subprocess.run(["nvidia-smi"], capture_output=True)
E   FileNotFoundError: [Errno 2] No such file or directory: 'nvidia-smi'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

`subprocess.run` **raises** `FileNotFoundError` when the binary does not exist
rather than returning a non-zero code, and `_gpu_available()` is evaluated at
**collection** time inside the `@pytest.mark.skipif` decorator. So on a runner
with no `nvidia-smi` the exception aborts collection of the whole file and
interrupts the entire suite.

This was masked during development: scorch has `nvidia-smi` at `/usr/bin`, so
`_gpu_available()` always returned cleanly. I noted that GPU tests would skip on
CI runners without a GPU, but assumed they would skip *gracefully* — they crash
collection instead.

## Verification

Reproduced in a container with no `nvidia-smi`, which fails collection
identically to CI:

```
ERROR tests/test_deeplearning.py - FileNotFoundError: [Errno 2] No such file ...
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

After the fix, in the same container: **379 tests collected**, no errors.

Also audited the remaining `subprocess` calls in `tests/`. The other two
(`docker_run` in conftest, and the `docker inspect` in `test_entrypoint_is_tini`)
run at test time rather than collection time, so a missing binary there fails one
test instead of aborting the run.

Note the suite has still never actually executed in CI, so this unblocks the
first real run rather than proving it green.