### PR TITLE
perf: batch container invocations, halving suite runtime

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,12 @@
-"""Shared fixtures for container tests."""
+"""Shared fixtures for container tests.
 
+Container startup dominates this suite's runtime, so anything invoked with the
+same arguments more than once goes through `cached_run`, and groups of Python
+imports are probed in a single container via `import_probe`. Both keep one test
+per package so failures stay granular.
+"""
+
+import base64
 import subprocess
 
 import pytest
@@ -19,6 +26,104 @@ def docker_run(image: str, command: str, timeout: int = 60, gpus: bool = False) 
         cmd += ["--gpus", "all"]
     cmd += [image, "bash", "-c", command]
     return subprocess.run(cmd, capture_output=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=timeout)
+
+
+def _run_python(image: str, script: str, timeout: int = 600) -> subprocess.CompletedProcess:
+    """Run a multi-line Python script in a container.
+
+    Base64 so the script survives the bash -c layer regardless of quoting.
+    """
+    encoded = base64.b64encode(script.encode()).decode()
+    return docker_run(image, f"echo {encoded} | base64 -d | python3", timeout=timeout)
+
+
+@pytest.fixture(scope="session")
+def cached_run():
+    """docker_run memoized on (image, command) for the whole session.
+
+    Several tests assert different things about the same command output -- the
+    extension lists were each re-running `jupyter labextension list`, ~1.5s a
+    time, twenty times over.
+    """
+    cache: dict = {}
+
+    def run(image: str, command: str, **kwargs) -> subprocess.CompletedProcess:
+        key = (image, command)
+        if key not in cache:
+            cache[key] = docker_run(image, command, **kwargs)
+        return cache[key]
+
+    return run
+
+
+@pytest.fixture(scope="session")
+def import_probe():
+    """Import a group of modules in ONE container; report each individually.
+
+    Returns {module: (ok, detail)}. Batching also means numba's first-import
+    cost is paid once per container rather than once per test.
+    """
+    cache: dict = {}
+
+    def probe(image: str, modules) -> dict:
+        modules = list(modules)
+        key = (image, tuple(modules))
+        if key not in cache:
+            script = (
+                "import importlib\n"
+                f"for m in {modules!r}:\n"
+                "    try:\n"
+                "        importlib.import_module(m)\n"
+                "        print('OK', m)\n"
+                "    except BaseException as e:\n"
+                "        print('FAIL', m, type(e).__name__, str(e).replace(chr(10), ' '))\n"
+            )
+            result = _run_python(image, script)
+            parsed = {}
+            for line in result.stdout.splitlines():
+                parts = line.split(None, 2)
+                if len(parts) >= 2 and parts[0] in ("OK", "FAIL"):
+                    parsed[parts[1]] = (parts[0] == "OK", parts[2] if len(parts) > 2 else "")
+            # Surface a probe that never ran rather than reporting every module absent
+            if not parsed:
+                pytest.fail(
+                    f"import probe produced no parsable output for {image}\n{result.stdout}"
+                )
+            cache[key] = parsed
+        return cache[key]
+
+    return probe
+
+
+@pytest.fixture(scope="session")
+def version_probe():
+    """Read installed versions for a group of packages in ONE container."""
+    cache: dict = {}
+
+    def probe(image: str, packages) -> dict:
+        packages = list(packages)
+        key = (image, tuple(packages))
+        if key not in cache:
+            script = (
+                "from importlib.metadata import version, PackageNotFoundError\n"
+                f"for p in {packages!r}:\n"
+                "    try:\n"
+                "        print(p, version(p))\n"
+                "    except PackageNotFoundError:\n"
+                "        print(p, 'MISSING')\n"
+            )
+            result = _run_python(image, script)
+            parsed = dict(
+                line.split(None, 1) for line in result.stdout.splitlines() if len(line.split()) == 2
+            )
+            if not parsed:
+                pytest.fail(
+                    f"version probe produced no parsable output for {image}\n{result.stdout}"
+                )
+            cache[key] = parsed
+        return cache[key]
+
+    return probe
 
 
 MINIMAL_IMAGES = ["brineylab/base", "brineylab/jupyterhub-base"]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -117,90 +117,89 @@ class TestEnvironment:
 #      Scientific stack
 # ----------------------------
 
-class TestScientificStack:
-    @pytest.mark.parametrize("package", [
-        "scipy",
-        "numpy",
-        "pandas",
-        "matplotlib",
-        "seaborn",
-        "scikit-learn",
-        "scikit-image",
-        "statsmodels",
-        "bokeh",
-        "dask",
-        "numba",
-        "h5py",
-        "sympy",
-        "sqlalchemy",
-        "altair",
-        "cython",
-        "pyarrow",
-        "tables",
-        "openpyxl",
-        "protobuf",
-        "ipympl",
-    ])
-    def test_scientific_import(self, stack_image, package):
-        import_name = (
-            package
-            .replace("scikit-learn", "sklearn")
-            .replace("scikit-image", "skimage")
-            .replace("protobuf", "google.protobuf")
-        )
-        result = docker_run(stack_image, f"python3 -c 'import {import_name}'")
-        assert result.returncode == 0, f"Failed to import {package}: {result.stdout}"
+# package name (the test id) -> module actually imported
+SCIENTIFIC_PACKAGES = {
+    "scipy": "scipy",
+    "numpy": "numpy",
+    "pandas": "pandas",
+    "matplotlib": "matplotlib",
+    "seaborn": "seaborn",
+    "scikit-learn": "sklearn",
+    "scikit-image": "skimage",
+    "statsmodels": "statsmodels",
+    "bokeh": "bokeh",
+    "dask": "dask",
+    "numba": "numba",
+    "h5py": "h5py",
+    "sympy": "sympy",
+    "sqlalchemy": "sqlalchemy",
+    "altair": "altair",
+    "cython": "cython",
+    "pyarrow": "pyarrow",
+    "tables": "tables",
+    "openpyxl": "openpyxl",
+    "protobuf": "google.protobuf",
+    "ipympl": "ipympl",
+}
 
-    def test_numpy_version_gte_2(self, stack_image):
-        result = docker_run(stack_image, "python3 -c 'import numpy; assert int(numpy.__version__.split(\".\")[0]) >= 2'")
-        assert result.returncode == 0, f"Expected numpy >= 2: {result.stdout}"
+
+class TestScientificStack:
+    @pytest.mark.parametrize("package", list(SCIENTIFIC_PACKAGES))
+    def test_scientific_import(self, stack_image, import_probe, package):
+        results = import_probe(stack_image, SCIENTIFIC_PACKAGES.values())
+        ok, detail = results.get(SCIENTIFIC_PACKAGES[package], (False, "not reported by probe"))
+        assert ok, f"Failed to import {package}: {detail}"
+
+    def test_numpy_version_gte_2(self, stack_image, version_probe):
+        version = version_probe(stack_image, ["numpy"])["numpy"]
+        assert int(version.split(".")[0]) >= 2, f"Expected numpy >= 2, got {version}"
 
 
 # ----------------------------
 #      Biology packages
 # ----------------------------
 
-class TestBiology:
-    @pytest.mark.parametrize("package", [
-        "scanpy",
-        "scvelo",
-        "bbknn",
-        "leidenalg",
-        "umap",
-        "biopython",
-        "parasail",
-        "doubletdetection",
-        "harmonypy",
-        "scanorama",
-        "scrublet",
-        "logomaker",
-        "dnachisel",
-        "pyfamsa",
-        # the lab's own ab[x] suite -- previously only abutils was covered
-        "abstar",
-        "scab",
-        # antibody numbering
-        "anarci",
-        "abnumber",
-    ])
-    def test_biology_import(self, stack_image, package):
-        import_name = package.replace("biopython", "Bio")
-        result = docker_run(stack_image, f"python3 -c 'import {import_name}'")
-        assert result.returncode == 0, f"Failed to import {package}: {result.stdout}"
+BIOLOGY_PACKAGES = {
+    "scanpy": "scanpy",
+    "scvelo": "scvelo",
+    "bbknn": "bbknn",
+    "leidenalg": "leidenalg",
+    "umap": "umap",
+    "biopython": "Bio",
+    "parasail": "parasail",
+    "doubletdetection": "doubletdetection",
+    "harmonypy": "harmonypy",
+    "scanorama": "scanorama",
+    "scrublet": "scrublet",
+    "logomaker": "logomaker",
+    "dnachisel": "dnachisel",
+    "pyfamsa": "pyfamsa",
+    # the lab's own ab[x] suite -- previously only abutils was covered
+    "abstar": "abstar",
+    "scab": "scab",
+    # antibody numbering
+    "anarci": "anarci",
+    "abnumber": "abnumber",
+}
 
-    def test_abutils_meets_pin(self, stack_image):
+
+class TestBiology:
+    @pytest.mark.parametrize("package", list(BIOLOGY_PACKAGES))
+    def test_biology_import(self, stack_image, import_probe, package):
+        results = import_probe(stack_image, BIOLOGY_PACKAGES.values())
+        ok, detail = results.get(BIOLOGY_PACKAGES[package], (False, "not reported by probe"))
+        assert ok, f"Failed to import {package}: {detail}"
+
+    def test_abutils_meets_pin(self, stack_image, version_probe):
         """pip.txt pins abutils>=0.6.0 (numpy 2 compatibility).
 
         Compares release tuples rather than substring-matching "0.6", which
         would reject a legitimate 1.x and accept an unrelated 10.6.
         """
-        result = docker_run(
-            stack_image,
-            "python3 -c 'from importlib.metadata import version; print(version(\"abutils\"))'",
-        )
-        assert result.returncode == 0, f"Failed to read abutils version: {result.stdout}"
-        parts = tuple(int(p) for p in result.stdout.strip().split(".")[:3] if p.isdigit())
-        assert parts >= (0, 6, 0), f"Expected abutils >= 0.6.0, got {result.stdout.strip()}"
+        version = version_probe(stack_image, SHARED_PINNED_PACKAGES)["abutils"]
+        assert version != "MISSING", "abutils not installed"
+        parts = tuple(int(p) for p in version.split(".")[:3] if p.isdigit())
+        assert parts >= (0, 6, 0), f"Expected abutils >= 0.6.0, got {version}"
 
     # Trastuzumab (Herceptin) heavy-chain variable domain -- real, published sequence.
     TRASTUZUMAB_VH = (
@@ -254,20 +253,24 @@ print('OK')
 #      Utility packages
 # ----------------------------
 
+UTILITY_MODULES = [
+    "duckdb",
+    "polars",
+    "paramiko",
+    "pymongo",
+    "pytest",
+    "yaml",
+    "tqdm",
+    "humanize",
+]
+
+
 class TestUtilities:
-    @pytest.mark.parametrize("package", [
-        "duckdb",
-        "polars",
-        "paramiko",
-        "pymongo",
-        "pytest",
-        "yaml",
-        "tqdm",
-        "humanize",
-    ])
-    def test_utility_import(self, stack_image, package):
-        result = docker_run(stack_image, f"python3 -c 'import {package}'")
-        assert result.returncode == 0, f"Failed to import {package}: {result.stdout}"
+    @pytest.mark.parametrize("module", UTILITY_MODULES)
+    def test_utility_import(self, stack_image, import_probe, module):
+        results = import_probe(stack_image, UTILITY_MODULES)
+        ok, detail = results.get(module, (False, "not reported by probe"))
+        assert ok, f"Failed to import {module}: {detail}"
 
 
 # ----------------------------
@@ -305,32 +308,33 @@ class TestR:
 #     Version consistency
 # ----------------------------
 
+SHARED_PINNED_PACKAGES = [
+    "numpy",
+    "scipy",
+    "pandas",
+    "scikit-learn",
+    "matplotlib",
+    "scanpy",
+    "abutils",
+    "fastcluster",
+    "h5py",
+    "seaborn",
+    "dask",
+    "numba",
+    "openpyxl",
+]
+
+
 class TestVersionConsistency:
     """Verify key packages have the same version across images."""
 
-    @pytest.mark.parametrize("package", [
-        "numpy",
-        "scipy",
-        "pandas",
-        "scikit-learn",
-        "matplotlib",
-        "scanpy",
-        "abutils",
-        "fastcluster",
-        "h5py",
-        "seaborn",
-        "dask",
-        "numba",
-        "openpyxl",
-    ])
-    def test_version_matches(self, request, package):
+    @pytest.mark.parametrize("package", SHARED_PINNED_PACKAGES)
+    def test_version_matches(self, request, version_probe, package):
         tag = request.config.getoption("--tag")
-        cmd = f"python3 -c 'import importlib.metadata; print(importlib.metadata.version(\"{package}\"))'"
+        ds = version_probe(f"brineylab/datascience:{tag}", SHARED_PINNED_PACKAGES)
+        dl = version_probe(f"brineylab/deeplearning:{tag}", SHARED_PINNED_PACKAGES)
 
-        ds = docker_run(f"brineylab/datascience:{tag}", cmd)
-        dl = docker_run(f"brineylab/deeplearning:{tag}", cmd)
-
-        assert ds.returncode == 0, f"datascience failed: {ds.stdout}"
-        assert dl.returncode == 0, f"deeplearning failed: {dl.stdout}"
-        assert ds.stdout.strip() == dl.stdout.strip(), \
-            f"{package}: datascience={ds.stdout.strip()} != deeplearning={dl.stdout.strip()}"
+        assert ds.get(package) != "MISSING", f"{package} not installed in datascience"
+        assert dl.get(package) != "MISSING", f"{package} not installed in deeplearning"
+        assert ds.get(package) == dl.get(package), \
+            f"{package}: datascience={ds.get(package)} != deeplearning={dl.get(package)}"

--- a/tests/test_deeplearning.py
+++ b/tests/test_deeplearning.py
@@ -33,34 +33,41 @@ def _gpu_available() -> bool:
 #      AI/ML packages
 # ----------------------------
 
+AIML_MODULES = [
+    "torch",
+    "lightning",
+    "deepspeed",
+    "wandb",
+    "jax",
+    "flax",
+    "optax",
+    "equinox",
+    "chex",
+    "accelerate",
+    "transformers",
+    "datasets",
+    "diffusers",
+    "peft",
+    "evaluate",
+    "optimum",
+    "gradio",
+    "tree",
+    "ml_collections",
+    "treescope",
+]
+
+
 class TestAIML:
-    @pytest.mark.parametrize("package", [
-        "torch",
-        "lightning",
-        "deepspeed",
-        "wandb",
-        "jax",
-        "flax",
-        "optax",
-        "equinox",
-        "chex",
-        "keras",
-        "accelerate",
-        "transformers",
-        "datasets",
-        "diffusers",
-        "peft",
-        "evaluate",
-        "optimum",
-        "gradio",
-        "tree",
-        "ml_collections",
-        "treescope",
-    ])
-    def test_aiml_import(self, image, package):
-        env = "KERAS_BACKEND=torch " if package == "keras" else ""
-        result = docker_run(image, f"{env}python3 -c 'import {package}'")
-        assert result.returncode == 0, f"Failed to import {package}: {result.stdout}"
+    @pytest.mark.parametrize("module", AIML_MODULES)
+    def test_aiml_import(self, image, import_probe, module):
+        results = import_probe(image, AIML_MODULES)
+        ok, detail = results.get(module, (False, "not reported by probe"))
+        assert ok, f"Failed to import {module}: {detail}"
+
+    def test_keras_import(self, image):
+        """Separate from the batch: keras needs a backend selected up front."""
+        result = docker_run(image, "KERAS_BACKEND=torch python3 -c 'import keras'", timeout=120)
+        assert result.returncode == 0, f"Failed to import keras: {result.stdout}"
 
     def test_torch_cuda_build(self, image):
         result = docker_run(image, "python3 -c 'import torch; print(torch.__version__)'")

--- a/tests/test_jupyterhub.py
+++ b/tests/test_jupyterhub.py
@@ -56,13 +56,13 @@ class TestJupyter:
 # ----------------------------
 
 class TestKernels:
-    def test_python_kernel(self, jupyterhub_image):
-        result = docker_run(jupyterhub_image, "jupyter kernelspec list")
+    def test_python_kernel(self, jupyterhub_image, cached_run):
+        result = cached_run(jupyterhub_image, "jupyter kernelspec list")
         assert result.returncode == 0
         assert "python3" in result.stdout
 
-    def test_r_kernel(self, jupyterhub_image):
-        result = docker_run(jupyterhub_image, "jupyter kernelspec list")
+    def test_r_kernel(self, jupyterhub_image, cached_run):
+        result = cached_run(jupyterhub_image, "jupyter kernelspec list")
         assert result.returncode == 0
         assert "ir" in result.stdout
 
@@ -79,9 +79,9 @@ class TestLabExtensions:
         "@marimo-team/jupyter-extension",
         "@jupyterhub/jupyter-server-proxy",
     ])
-    def test_lab_extension(self, jupyterhub_image, extension):
+    def test_lab_extension(self, jupyterhub_image, cached_run, extension):
         """Extensions installed from jupyter_pip.txt, so present in every variant."""
-        result = docker_run(jupyterhub_image, "jupyter labextension list")
+        result = cached_run(jupyterhub_image, "jupyter labextension list")
         assert extension in result.stdout, \
             f"{extension} not found in labextension list"
 
@@ -89,19 +89,19 @@ class TestLabExtensions:
         "jupyter-matplotlib",
         "@jupyter-widgets/jupyterlab-manager",
     ])
-    def test_stack_lab_extension(self, stack_jupyterhub_image, extension):
+    def test_stack_lab_extension(self, stack_jupyterhub_image, cached_run, extension):
         """Extensions that arrive with the scientific stack rather than with Jupyter.
 
         jupyter-matplotlib comes from ipympl in pip.txt and jupyterlab-manager
         from ipywidgets pulled in transitively, so jupyterhub-base has neither.
         """
-        result = docker_run(stack_jupyterhub_image, "jupyter labextension list")
+        result = cached_run(stack_jupyterhub_image, "jupyter labextension list")
         assert extension in result.stdout, \
             f"{extension} not found in labextension list"
 
-    def test_nvdashboard(self, request):
+    def test_nvdashboard(self, request, cached_run):
         tag = request.config.getoption("--tag")
-        result = docker_run(f"brineylab/jupyterhub-deeplearning:{tag}", "jupyter labextension list")
+        result = cached_run(f"brineylab/jupyterhub-deeplearning:{tag}", "jupyter labextension list")
         assert "nvdashboard" in result.stdout
 
 
@@ -118,12 +118,12 @@ class TestServerExtensions:
         "notebook",
         "jupyter_server_proxy",
     ])
-    def test_server_extension(self, jupyterhub_image, extension):
-        result = docker_run(jupyterhub_image, "jupyter server extension list")
+    def test_server_extension(self, jupyterhub_image, cached_run, extension):
+        result = cached_run(jupyterhub_image, "jupyter server extension list")
         assert extension in result.stdout, \
             f"{extension} not found in server extension list"
 
-    def test_nvdashboard_server(self, request):
+    def test_nvdashboard_server(self, request, cached_run):
         tag = request.config.getoption("--tag")
-        result = docker_run(f"brineylab/jupyterhub-deeplearning:{tag}", "jupyter server extension list")
+        result = cached_run(f"brineylab/jupyterhub-deeplearning:{tag}", "jupyter server extension list")
         assert "jupyterlab_nvdashboard" in result.stdout


### PR DESCRIPTION
The test job took **15:28** on the v2026-07-29 release. Step breakdown:

| step | time |
|---|---|
| pull images | 5:19 |
| **run tests** | **9:56** |
| everything else | ~10s |

Cause: the suite spawned **one container per assertion** — 379 `docker run`
invocations, each paying interpreter startup and, for the scientific imports, a
fresh numba warm-up.

## Changes

**`import_probe` / `version_probe`** run a group of imports or version lookups in
a single container and report each item individually. Measured on the 21
scientific imports against `datascience`: 21 separate containers **15s**, one
batched container **5s**.

**`cached_run`** memoizes `docker_run` on `(image, command)` for the session. The
extension tests were each re-running `jupyter labextension list` — **1.48s a
time, 20 times over** — and `jupyter server extension list` **19 times**. Those
collapse to one invocation per image.

Both keep **one test per package**, so a failure is still
`FAILED …test_biology_import[brineylab/datascience-bbknn]` rather than one opaque
error. Package name and import name are now separate (`scikit-learn` → `sklearn`)
instead of chained `.replace()` calls.

## Result

**379 tests, all passing, 6:24 → 3:06 locally** (52% faster). CI pytest was 9:56,
so the job should land near **10 minutes**, with the remaining 5:19 being pulls.

The slowest entries now (`torch` 12.8s, `scanpy` 12.2s) are the batch probes
themselves, attributed to whichever test triggers them — that is the real cost of
importing those trees, not overhead.

## Verification

Same 379 tests collected and passing. I also checked that batching did not
weaken failure reporting: a probe against an image missing a module still
attributes it to that specific package and surfaces `ModuleNotFoundError`, and
`version_probe` marks absent packages `MISSING` rather than silently passing.

## Left on the table, deliberately

`TestEnvironment` is now the largest remaining block at **96 invocations**
(16 checks × 6 images), and `TestJupyter` another 27. Those are 96 *distinct*
trivial commands rather than repeated ones, so batching them is pure
container-startup amortization — worth maybe another 90s, but it would turn the
clearest tests in the suite into probe lookups and needs fiddly shell output
parsing. Happy to do it if the runtime matters more than the readability, which
it would if these ever gate a PR rather than running post-publish.