### PR TITLE
fix: hold anndata at the 0.12 line, add h5ad regression tests

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -32,6 +32,9 @@ sympy
 tables
 
 # biology
+# <0.13 blocks the None-in-.layers bug; >=0.12.19 is the first with the pandas 3.0
+# h5ad write fix. Currently resolves to 0.12.19; floats forward on 0.12 patches.
+anndata>=0.12.19,<0.13
 abnumber
 anarci
 baltic

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,7 +5,7 @@ import subprocess
 
 import pytest
 
-from conftest import docker_run
+from conftest import _run_python, docker_run
 
 
 # ----------------------------
@@ -247,6 +247,56 @@ print('OK')
 " """)
         assert result.returncode == 0, f"fastcluster test failed: {result.stdout}"
         assert "OK" in result.stdout
+
+
+# ----------------------------
+#      AnnData / h5ad
+# ----------------------------
+
+class TestAnnData:
+    """Regression guards for two anndata bugs an import test would miss."""
+
+    def test_h5ad_write_with_string_obs_index(self, stack_image):
+        """Save an AnnData with a string obs index (anndata 0.12.6 raised on this)."""
+        script = """
+import numpy as np, pandas as pd, anndata as ad, scipy.sparse as sp
+rng = np.random.default_rng(0)
+X = sp.csr_matrix(rng.random((10, 4), dtype=np.float32))
+obs = pd.DataFrame({"cell": [f"c{i}" for i in range(10)]}).set_index("cell")
+a = ad.AnnData(X=X, obs=obs, var=pd.DataFrame(index=[f"g{i}" for i in range(4)]))
+a.write_h5ad("/tmp/t.h5ad")
+b = ad.read_h5ad("/tmp/t.h5ad")
+assert b.shape == (10, 4), b.shape
+assert list(b.obs_names[:2]) == ["c0", "c1"], list(b.obs_names[:2])
+print("H5AD_OK")
+"""
+        result = _run_python(stack_image, script, timeout=180)
+        assert "H5AD_OK" in result.stdout, f"h5ad round-trip failed:\n{result.stdout}"
+
+    def test_layers_keys_are_strings(self, stack_image):
+        """.layers must not yield a None key (anndata 0.13 exposes X as layers[None])."""
+        script = """
+import numpy as np, pandas as pd, anndata as ad, scipy.sparse as sp
+rng = np.random.default_rng(0)
+X = sp.csr_matrix(rng.random((10, 4), dtype=np.float32))
+a = ad.AnnData(X=X, obs=pd.DataFrame(index=[f"c{i}" for i in range(10)]),
+               var=pd.DataFrame(index=[f"g{i}" for i in range(4)]))
+a.layers["counts"] = X.copy()
+a.write_h5ad("/tmp/l.h5ad")
+b = ad.read_h5ad("/tmp/l.h5ad")
+keys = list(b.layers)
+print("LAYER_KEYS", repr(keys))
+print("LAYER_LEN", len(b.layers))
+"""
+        result = _run_python(stack_image, script, timeout=180)
+        assert "LAYER_KEYS" in result.stdout, result.stdout
+        keys_line = [l for l in result.stdout.splitlines() if l.startswith("LAYER_KEYS")][0]
+        assert "None" not in keys_line, (
+            f"anndata exposes a None layer key (X); iterating .layers will "
+            f"silently touch X and sorted(keys()) raises TypeError -- {keys_line}"
+        )
+        len_line = [l for l in result.stdout.splitlines() if l.startswith("LAYER_LEN")][0]
+        assert len_line.split()[1] == "1", f"expected exactly one layer -- {len_line}"
 
 
 # ----------------------------


### PR DESCRIPTION
Found by diffing `v2026-05-26` against `v2026-07-29` package-by-package. Neither
issue would be caught by an import test — both packages import fine.

## The regression: anndata 0.13 adds a `None` layer key

`anndata` 0.13 exposes `X` as a `None`-keyed entry in `.layers`, so it lands in
`keys()`, `len()` and iteration. Confirmed `adata.layers[None] is X`.

| | 0.12.19 | 0.13.2 |
|---|---|---|
| `list(adata.layers)` | `['counts']` | `['counts', None]` |
| `len(adata.layers)` | 1 | 2 |
| `sorted(adata.layers.keys())` | works | **TypeError** |
| `k.startswith(...)` on keys | works | **AttributeError** |

Two ordinary scanpy/scab patterns break: `for k in adata.layers: adata.layers[k] = ...`
silently writes to `X` on the extra iteration, and sorting layer names raises.

**Fix: `anndata>=0.12.19,<0.13`.** 0.12.19 has neither problem — string-only
layer keys, *and* it carries the pandas 3.0 write fix described below. Verified
the constraint resolves cleanly against the full `pip.txt` (anndata 0.12.19 with
scanpy 1.12.3, no conflict). 0.13.2 is the latest release, so there is nothing
newer to move to; the pin should be revisited when upstream restores
string-only keys.

## The bug the last release already fixed, now guarded

`v2026-05-26` **could not save any AnnData with a string obs index**:

```
IORegistryError: No method registered for writing
<class 'pandas.arrays.ArrowStringArray'> into <class 'h5py._hl.group.Group'>
Error raised while writing key 'cell' of ... to /obs
```

pandas 3.0 backs string columns with Arrow arrays and anndata 0.12.6 had no
writer for them. Since obs indices are strings by definition, `write_h5ad` was
broken for every scanpy object — for two months, silently, because nothing
tested it. Already fixed by the version bump; `test_h5ad_write_with_string_obs_index`
now guards against reintroduction.

## Verification

- `test_layers_keys_are_strings` fails on 0.13.2 (`LAYER_KEYS ['counts', None]`)
  and passes on 0.12.19 — watched it go red before applying the pin.
- `test_h5ad_write_with_string_obs_index` passes on current images.
- 51 scientific / biology / utility / antibody-numbering tests still pass against
  a build carrying the pin, so the downgrade breaks nothing else.
- Data written by either anndata version reads correctly in the other.

## Worth reporting upstream

The `None` key looks like an unintended consequence of `layers[None]` meaning
`X` — a real anndata convention — leaking into the mapping's key view. Worth an
issue against anndata, at which point this pin can be dropped.