### PR TITLE
test: prune redundant tests, harden probes, batch TestEnvironment

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,7 @@
 """Shared fixtures for container tests.
 
-Container startup dominates this suite's runtime, so anything invoked with the
-same arguments more than once goes through `cached_run`, and groups of Python
-imports are probed in a single container via `import_probe`. Both keep one test
-per package so failures stay granular.
+Container startup dominates runtime, so repeated commands go through `cached_run`
+and grouped imports through `import_probe` -- one container, one test per package.
 """
 
 import base64
@@ -39,12 +37,7 @@ def _run_python(image: str, script: str, timeout: int = 600) -> subprocess.Compl
 
 @pytest.fixture(scope="session")
 def cached_run():
-    """docker_run memoized on (image, command) for the whole session.
-
-    Several tests assert different things about the same command output -- the
-    extension lists were each re-running `jupyter labextension list`, ~1.5s a
-    time, twenty times over.
-    """
+    """docker_run memoized on (image, command) for the session."""
     cache: dict = {}
 
     def run(image: str, command: str, **kwargs) -> subprocess.CompletedProcess:
@@ -58,11 +51,7 @@ def cached_run():
 
 @pytest.fixture(scope="session")
 def import_probe():
-    """Import a group of modules in ONE container; report each individually.
-
-    Returns {module: (ok, detail)}. Batching also means numba's first-import
-    cost is paid once per container rather than once per test.
-    """
+    """Import a group of modules in ONE container. Returns {module: (ok, detail)}."""
     cache: dict = {}
 
     def probe(image: str, modules) -> dict:
@@ -84,8 +73,7 @@ def import_probe():
                 parts = line.split(None, 2)
                 if len(parts) >= 2 and parts[0] in ("OK", "FAIL"):
                     parsed[parts[1]] = (parts[0] == "OK", parts[2] if len(parts) > 2 else "")
-            # Surface a probe that never ran rather than reporting every module absent
-            if not parsed:
+            if not parsed:  # probe never ran; don't report every module absent
                 pytest.fail(
                     f"import probe produced no parsable output for {image}\n{result.stdout}"
                 )
@@ -108,20 +96,64 @@ def version_probe():
                 "from importlib.metadata import version, PackageNotFoundError\n"
                 f"for p in {packages!r}:\n"
                 "    try:\n"
-                "        print(p, version(p))\n"
+                "        print('VER', p, version(p))\n"
                 "    except PackageNotFoundError:\n"
-                "        print(p, 'MISSING')\n"
+                "        print('VER', p, 'MISSING')\n"
             )
             result = _run_python(image, script)
-            parsed = dict(
-                line.split(None, 1) for line in result.stdout.splitlines() if len(line.split()) == 2
-            )
+            # 'VER' prefix so a stray two-word warning can't parse in
+            parsed = {}
+            for line in result.stdout.splitlines():
+                parts = line.split(None, 2)
+                if len(parts) == 3 and parts[0] == "VER":
+                    parsed[parts[1]] = parts[2]
             if not parsed:
                 pytest.fail(
                     f"version probe produced no parsable output for {image}\n{result.stdout}"
                 )
             cache[key] = parsed
         return cache[key]
+
+    return probe
+
+
+# Everything TestEnvironment checks, emitted as key<TAB>value, one container per image.
+_ENV_PROBE_SCRIPT = r"""
+emit() { printf '%s\t%s\n' "$1" "$2"; }
+emit which_python3  "$(which python3)"
+emit python_version "$(python3 --version 2>&1)"
+emit unique_python  "$(which -a python3 | xargs -n1 readlink -f | sort -u | wc -l | tr -d '[:space:]')"
+emit which_mamba    "$(which mamba)"
+emit conda_rc       "$(which conda >/dev/null 2>&1; echo $?)"
+emit uv_rc          "$(which uv >/dev/null 2>&1; echo $?)"
+emit rscript_rc     "$(Rscript --version >/dev/null 2>&1; echo $?)"
+emit which_tini     "$(which tini)"
+emit git_rc         "$(git --version >/dev/null 2>&1; echo $?)"
+emit gh_rc          "$(gh --version >/dev/null 2>&1; echo $?)"
+emit s5cmd_rc       "$(s5cmd version >/dev/null 2>&1; echo $?)"
+emit home_dir       "$(test -d /home/jovyan && echo yes || echo no)"
+emit umask          "$(bash -ic umask 2>/dev/null | tr -d '[:space:]')"
+emit uid            "$(id -u)"
+"""
+
+
+@pytest.fixture(scope="session")
+def env_probe():
+    """Run every environment check in ONE container per image. Returns {key: value}."""
+    cache: dict = {}
+
+    def probe(image: str) -> dict:
+        if image not in cache:
+            result = docker_run(image, _ENV_PROBE_SCRIPT, timeout=120)
+            env = {}
+            for line in result.stdout.splitlines():
+                if "\t" in line:
+                    k, v = line.split("\t", 1)
+                    env[k] = v
+            if "uid" not in env:  # last line emitted; absent means script died early
+                pytest.fail(f"env probe incomplete for {image}\n{result.stdout}")
+            cache[image] = env
+        return cache[image]
 
     return probe
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -12,96 +12,55 @@ from conftest import _run_python, docker_run
 #      Environment
 # ----------------------------
 
-# These are invariants of every published image, including the minimal base
-# images, so they run against any_image rather than just the stack images.
+# Invariants of every image; shell checks share one container per image via env_probe.
 class TestEnvironment:
-    def test_python_location(self, any_image):
-        result = docker_run(any_image, "which python3")
-        assert result.returncode == 0
-        assert "/opt/conda/bin/python3" in result.stdout
+    def test_python_location(self, any_image, env_probe):
+        assert env_probe(any_image)["which_python3"] == "/opt/conda/bin/python3"
 
-    def test_python_version(self, any_image):
-        result = docker_run(any_image, "python3 --version")
-        assert result.returncode == 0
-        assert "3.12" in result.stdout
+    def test_python_version(self, any_image, env_probe):
+        assert "3.12" in env_probe(any_image)["python_version"]
 
-    def test_no_third_python(self, any_image):
-        """Exactly two interpreters: conda's and Ubuntu's system python3.
+    def test_no_third_python(self, any_image, env_probe):
+        """Only conda + Ubuntu python3; 0b374c0 dropped NVIDIA's third interpreter."""
+        count = env_probe(any_image)["unique_python"]
+        assert count == "2", f"expected conda + system python only, found {count}"
 
-        0b374c0 switched deeplearning to CUDA DL Base to drop a *third* Python
-        that NVIDIA's PyTorch image bundled. Ubuntu's /usr/bin/python3 is
-        unavoidable and harmless as long as conda's wins on PATH, which
-        test_python_location covers. Symlinks are resolved because /bin/python3
-        and /usr/bin/python3 are the same file.
-        """
-        result = docker_run(
-            any_image, "which -a python3 | xargs -n1 readlink -f | sort -u | wc -l"
-        )
-        assert result.returncode == 0
-        assert result.stdout.strip() == "2", \
-            f"expected conda + system python only, found {result.stdout.strip()} interpreters"
+    def test_mamba(self, any_image, env_probe):
+        assert env_probe(any_image)["which_mamba"] == "/opt/conda/bin/mamba"
 
-    def test_mamba(self, any_image):
-        result = docker_run(any_image, "which mamba")
-        assert result.returncode == 0
-        assert "/opt/conda/bin/mamba" in result.stdout
+    def test_conda(self, any_image, env_probe):
+        assert env_probe(any_image)["conda_rc"] == "0", "conda not on PATH"
 
-    def test_conda(self, any_image):
-        result = docker_run(any_image, "which conda")
-        assert result.returncode == 0
+    def test_uv(self, any_image, env_probe):
+        assert env_probe(any_image)["uv_rc"] == "0", "uv not on PATH"
 
-    def test_uv(self, any_image):
-        result = docker_run(any_image, "which uv")
-        assert result.returncode == 0
+    def test_r(self, any_image, env_probe):
+        assert env_probe(any_image)["rscript_rc"] == "0", "Rscript not runnable"
 
-    def test_r(self, any_image):
-        result = docker_run(any_image, "Rscript --version")
-        assert result.returncode == 0
+    def test_tini(self, any_image, env_probe):
+        assert env_probe(any_image)["which_tini"], "tini not on PATH"
 
-    def test_tini(self, any_image):
-        result = docker_run(any_image, "which tini")
-        assert result.returncode == 0
+    def test_git(self, any_image, env_probe):
+        assert env_probe(any_image)["git_rc"] == "0", "git not runnable"
 
-    def test_git(self, any_image):
-        result = docker_run(any_image, "git --version")
-        assert result.returncode == 0
-
-    def test_gh(self, any_image):
+    def test_gh(self, any_image, env_probe):
         """GitHub CLI, installed via apt.txt so it reaches every image."""
-        result = docker_run(any_image, "gh --version")
-        assert result.returncode == 0
+        assert env_probe(any_image)["gh_rc"] == "0", "gh not runnable"
 
-    def test_s5cmd(self, any_image):
-        result = docker_run(any_image, "s5cmd version")
-        assert result.returncode == 0
+    def test_s5cmd(self, any_image, env_probe):
+        assert env_probe(any_image)["s5cmd_rc"] == "0", "s5cmd not runnable"
 
-    def test_conda_dir_exists(self, any_image):
-        result = docker_run(any_image, "test -d /opt/conda")
-        assert result.returncode == 0
-
-    def test_home_dir_exists(self, any_image):
+    def test_home_dir_exists(self, any_image, env_probe):
         """HOME is created in the image; work/ and shared/ arrive as NFS mounts."""
-        result = docker_run(any_image, "test -d /home/jovyan")
-        assert result.returncode == 0
+        assert env_probe(any_image)["home_dir"] == "yes"
 
-    def test_umask_is_000_in_interactive_shell(self, any_image):
-        """umask 000 is set in /etc/bash.bashrc.
+    def test_umask_is_000_in_interactive_shell(self, any_image, env_probe):
+        """umask 000 from /etc/bash.bashrc -- interactive shells only, not kernels."""
+        assert env_probe(any_image)["umask"] == "0000"
 
-        Scope matters: bash sources that file only for interactive shells, so
-        this covers terminal sessions but NOT files written by a notebook
-        kernel, which inherits the server process umask instead. Group-writable
-        notebook output on shared NFS depends on NB_UMASK in the singleuser pod
-        spec, which no image test can verify.
-        """
-        result = docker_run(any_image, "bash -ic umask")
-        assert result.returncode == 0
-        assert "0000" in result.stdout
-
-    def test_runs_as_root(self, any_image):
-        """85fbee4 removed the jovyan user; these images always run as root."""
-        result = docker_run(any_image, "id -u")
-        assert result.returncode == 0
-        assert result.stdout.strip() == "0"
+    def test_runs_as_root(self, any_image, env_probe):
+        """85fbee4 removed jovyan; images run as root."""
+        assert env_probe(any_image)["uid"] == "0"
 
     def test_entrypoint_is_tini(self, any_image):
         """tini reaps zombies; losing it from ENTRYPOINT would be silent."""

--- a/tests/test_datascience.py
+++ b/tests/test_datascience.py
@@ -48,15 +48,8 @@ class TestNGSTools:
 
 class TestNGSPaths:
     def test_tools_dir(self, image):
+        # Paired with test_no_ngs_tools (asserts /tools absent in base images).
         result = docker_run(image, "test -d /tools")
-        assert result.returncode == 0
-
-    def test_cellranger_in_path(self, image):
-        result = docker_run(image, "echo $PATH | grep -q cellranger")
-        assert result.returncode == 0
-
-    def test_dorado_in_path(self, image):
-        result = docker_run(image, "echo $PATH | grep -q dorado")
         assert result.returncode == 0
 
 

--- a/tests/test_jupyterhub.py
+++ b/tests/test_jupyterhub.py
@@ -35,9 +35,7 @@ class TestJupyter:
         result = docker_run(jupyterhub_image, "test -f /etc/jupyter/docker_healthcheck.py")
         assert result.returncode == 0
 
-    # -x rather than -f: these are exec'd as commands (start-notebook.py is CMD,
-    # and it execvp's start-singleuser.py), so a present-but-non-executable file
-    # is a broken image that -f would not catch.
+    # -x not -f: these are exec'd, so a non-executable file is broken but -f passes.
     def test_start_notebook_executable(self, jupyterhub_image):
         result = docker_run(jupyterhub_image, "test -x /usr/local/bin/start-notebook.py")
         assert result.returncode == 0, "start-notebook.py is not executable"
@@ -82,6 +80,7 @@ class TestLabExtensions:
     def test_lab_extension(self, jupyterhub_image, cached_run, extension):
         """Extensions installed from jupyter_pip.txt, so present in every variant."""
         result = cached_run(jupyterhub_image, "jupyter labextension list")
+        assert result.returncode == 0, f"labextension list failed: {result.stdout}"
         assert extension in result.stdout, \
             f"{extension} not found in labextension list"
 
@@ -96,12 +95,14 @@ class TestLabExtensions:
         from ipywidgets pulled in transitively, so jupyterhub-base has neither.
         """
         result = cached_run(stack_jupyterhub_image, "jupyter labextension list")
+        assert result.returncode == 0, f"labextension list failed: {result.stdout}"
         assert extension in result.stdout, \
             f"{extension} not found in labextension list"
 
     def test_nvdashboard(self, request, cached_run):
         tag = request.config.getoption("--tag")
         result = cached_run(f"brineylab/jupyterhub-deeplearning:{tag}", "jupyter labextension list")
+        assert result.returncode == 0, f"labextension list failed: {result.stdout}"
         assert "nvdashboard" in result.stdout
 
 
@@ -120,10 +121,12 @@ class TestServerExtensions:
     ])
     def test_server_extension(self, jupyterhub_image, cached_run, extension):
         result = cached_run(jupyterhub_image, "jupyter server extension list")
+        assert result.returncode == 0, f"server extension list failed: {result.stdout}"
         assert extension in result.stdout, \
             f"{extension} not found in server extension list"
 
     def test_nvdashboard_server(self, request, cached_run):
         tag = request.config.getoption("--tag")
         result = cached_run(f"brineylab/jupyterhub-deeplearning:{tag}", "jupyter server extension list")
+        assert result.returncode == 0, f"server extension list failed: {result.stdout}"
         assert "jupyterlab_nvdashboard" in result.stdout


### PR DESCRIPTION
Acting on a review of the existing suite. **No coverage is lost** — everything
removed is proven redundant, and the batching keeps one test per check.

## Removed — redundant, covered strictly better elsewhere

- **`test_cellranger_in_path`, `test_dorado_in_path`** — `test_cellranger`
  (`cellranger --version`) and `test_dorado` (`which dorado`) already prove PATH
  resolution definitionally. The removed greps (`echo $PATH | grep -q dorado`)
  only passed because the version-pinned directory name `dorado-0.7.0-linux-x64`
  happens to contain the substring `dorado` — redundant **and** fragile to a
  version bump.
- **`test_conda_dir_exists`** — `/opt/conda` existing is entailed by
  `test_python_location` and `test_mamba`, which assert `/opt/conda/bin/python3`
  and `/opt/conda/bin/mamba`.

## Fixed — right intent, weak setup

- The five `jupyter` **extension tests** asserted `extension in stdout` but never
  checked the command succeeded. A `jupyter labextension list` that errored
  could pass or fail on incidental output. Added `returncode == 0` asserts.
- **`version_probe`** blindly parsed any two-token line into its dict, so a stray
  two-word warning could land as a bogus package/version. Gave it a `VER`
  sentinel prefix, matching `import_probe`'s existing robustness.

## Batched — TestEnvironment

It spawned **one container per check per image** — ~90 `docker run`s of trivial
`which`/`test` commands, the largest block in the suite. A session-scoped
`env_probe` now runs the whole battery once per image and returns a `{key: value}`
dict; each test stays a separate lookup so a failure still names the exact check.

- That block: **~90 spawns → 6**, 2.75s for 90 tests.
- Full suite: **~3:06 → 2:40 locally**; the CI win is larger since container
  startup costs more there.
- `test_entrypoint_is_tini` keeps its `docker inspect` — that's image metadata,
  not a container run, and already cheap.

## Verification

- 371 tests pass against the current published images (was 379; −8 = −6
  conda_dir_exists across images, −2 in_path).
- Confirmed the batched env checks keep their teeth: assertions compare exact
  values (`which_python3 == /opt/conda/bin/python3`, `uid == 0`,
  `unique_python == 2`), so a wrong value fails.
- `env_probe` fails loudly if its script dies early (checks the last-emitted key
  is present) rather than silently reporting everything absent.

Independent of #63 and #64; touches different regions, so it can merge in any
order (a rebase may be needed for whichever lands second).